### PR TITLE
add GUIDE_UPDATE_INTERVAL to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ ENV NAME="Tablo 4th Gen Proxy" \
     USER_PASS="pass" \
     GUIDE_UPDATE_INTERVAL=24
 
-CMD node app.js --name $NAME --id $DEVICE_ID --interval $LINEUP_UPDATE_INTERVAL --xml $CREATE_XML --days $GUIDE_DAYS --pseudo $INCLUDE_PSEUDOTV_GUIDE --level $LOG_LEVEL --log $SAVE_LOG --outdir /outdir --user $USER_NAME --pass $USER_PASS --guide $GUIDE_UPDATE_INTERVAL
+CMD node app.js --name $NAME --id $DEVICE_ID --interval $LINEUP_UPDATE_INTERVAL --xml $CREATE_XML --days $GUIDE_DAYS --pseudo $INCLUDE_PSEUDOTV_GUIDE --level $LOG_LEVEL --log $SAVE_LOG --outdir /output --user $USER_NAME --pass $USER_PASS --guide $GUIDE_UPDATE_INTERVAL


### PR DESCRIPTION
Add support for new GUIDE_UPDATE_INTERVAL parameter (introduced in [v0.9.12](https://github.com/hearhellacopters/tablo2plex/releases/tag/v0.9.12)) to Dockerfile for container builds.