### PR TITLE
fix missing line continuation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV NAME="Tablo 4th Gen Proxy" \
     SAVE_LOG="true" \
     USER_NAME="user" \
     USER_PASS="pass" \
-    GUIDE_UPDATE_INTERVAL=24
+    GUIDE_UPDATE_INTERVAL=24 \
     INCLUDE_OTT="true"
 
 CMD node app.js --name $NAME --id $DEVICE_ID --interval $LINEUP_UPDATE_INTERVAL --xml $CREATE_XML --days $GUIDE_DAYS --pseudo $INCLUDE_PSEUDOTV_GUIDE --level $LOG_LEVEL --log $SAVE_LOG --outdir /output --user $USER_NAME --pass $USER_PASS --guide $GUIDE_UPDATE_INTERVAL --ott $INCLUDE_OTT


### PR DESCRIPTION
Thanks for updating the Dockerfile with the new command-line parameter, but you missed the line continuation marker on the previous line. 😀 