### PR TITLE
Fix channel number format to use major.minor instead of majorminor1

### DIFF
--- a/src/Device.js
+++ b/src/Device.js
@@ -942,7 +942,7 @@ async function parseGuideData(lineUp) {
             var channelNum = "";
 
             if (el.kind == "ota") {
-                channelNum = `${el.ota.major}${el.ota.minor}1`;
+                channelNum = `${el.ota.major}.${el.ota.minor}`;
 
                 xw.writeAttribute('id', channelNum);
 
@@ -1356,7 +1356,7 @@ async function parseLineup(lineup = undefined) {
                 var GuideNumber = `${el.ota.major}.${el.ota.minor}`;
 
                 if(CONST.CREATE_XML){
-                    GuideNumber = `${el.ota.major}${el.ota.minor}1`;
+                    GuideNumber = `${el.ota.major}.${el.ota.minor}`;
                 }
 
                 LINEUP_DATA[el.identifier] = {


### PR DESCRIPTION
Channels and subchannels were showing up in Plex as 211 for 2.1, 6531 for 65.3, etc. when using guide.xml from Tablo.  This change has resolved the issue.